### PR TITLE
Saxon Capital and Ibero-Celtic Culture Names #238

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -63,6 +63,8 @@ MINOR:
 - Removed the name Thresiamma with Christian connections to Teresa from the Dravidian cultures as suggested on the forums
 - Added an event about the invention of the Greek fire as flavour and to prevent it from being mentionned prior to it
 - Moved a holy site of the Celtic pagan religion from Somerset to Vannes in Brittany
+- Moved the Saxon capital from Anhalt to Celle
+- Modified the name lists for the Astures and and Cantabrian cultures
 
 2016-12-21 v0.9.9.1
 -----------------

--- a/WTWSMS/common/cultures/00_cultures.txt
+++ b/WTWSMS/common/cultures/00_cultures.txt
@@ -4787,11 +4787,23 @@ continental_celtic = {
 
 		color = { 0.7 0.5 0.2 }
 		male_names = {
-			Catullus Vertirius Donnodumnus Castillus Celtinus Deiogenus Amicos Lutavolcus Conconneledes Camulotiacus Epatorix Diviciacus Camulocos Viridothreus Acichosgus Cassiciacus Sedutiacus Segomarus Bellogon Togovolcus Valetignatus Aminus Bellovellaunus Litatius Deioccus Teutotix Vertivolcus Cambauviccus Boduothreus Autaricos Cingelus Adiamarus Prasurius Litavilus Acichocos Viridomarus Adiacomborius Valetivettius Ortialedes Olyndicomborius Valetilus Cavarillus Convictotorix Valetimatus Togolitavis Teutogon Castitiacus Sologenus Moritaciacus Taximagulitavis Eporevanus Crigenus Castimatus Boduoledes Convictodumnus Luctesgus Moritatiacus Vertibracius Sedugenus Rianociacus Cambaugon Viridodumnus Convictognatus Gaulavellaunus Cambaucatus Orgecus Orgevix Adiatunnus Segociacus Cavarilitavis Donnoledes Sinotagus Crisgus Amiccus Orgedumnus Deiosgus Viridorius Catamantaco Divivesus Celtitus Senniaco Cotuacus Vertidumnus Cassicos Rianovix Casticus Crisnactus Tascioco Boduotix Bellotiacus Viridoco Segoco Bellocos Orgemarus 
-			Taximagumatus Boduovettius Catamantarix Boduovolcus Senacubracius Catamantaledes Gauson
+			Abieno Aravo Blecaeno Blegino Boderoso Budetio Burracio Clouto Clutamo Clutos Coedo Dotio Eburo Elaeso 
+			Flao Fuscus Magilo Nicer Pentilo Catullus Vertirius Donnodumnus Castillus Celtinus Deiogenus Amicos Lutavolcus 
+			Conconneledes Camulotiacus Epatorix Diviciacus Camulocos Viridothreus Acichosgus Cassiciacus Sedutiacus Segomarus 
+			Bellogon Togovolcus Valetignatus Aminus Bellovellaunus Litatius Deioccus Teutotix Vertivolcus Cambauviccus Boduothreus 
+			Autaricos Cingelus Adiamarus Prasurius Litavilus Acichocos Viridomarus Adiacomborius Valetivettius Ortialedes 
+			Olyndicomborius Valetilus Cavarillus Convictotorix Valetimatus Togolitavis Teutogon Castitiacus Sologenus Moritaciacus 
+			Taximagulitavis Eporevanus Crigenus Castimatus Boduoledes Convictodumnus Luctesgus Moritatiacus Vertibracius Sedugenus 
+			Rianociacus Cambaugon Viridodumnus Convictognatus Gaulavellaunus Cambaucatus Orgecus Orgevix Adiatunnus Segociacus Cavarilitavis 
+			Donnoledes Sinotagus Crisgus Amiccus Orgedumnus Deiosgus Viridorius Catamantaco Divivesus Celtitus Senniaco Cotuacus 
+			Vertidumnus Cassicos Rianovix Casticus Crisnactus Tascioco Boduotix Bellotiacus Viridoco Segoco Bellocos Orgemarus 
 		}
 		female_names = {
-			Valuinna Galisama Sulona Nanterta Osmubodva Cataseibra Cunila Cunona Epubodva Vevicca Nemetantona Bouderta Brigentina Androna Agrosuelta Matrila Osmerta Andricca Caterta Rigentina Belisama Sulantona Morgisama Agraseibra Osmila Covicca Morgosuelt Sulila Veventina Matrantona Ardona Rigantia Valubodva Matrantia Androsuelta Agrentina Valila Covisama Belentina Senosuelta Catosuelta Galubodva Brigantona Morgasta Sulosuelta Volcerta Covantia Senisama Matrubodva Sirasta Rigubodva Morgerta Sirantia Epila Senantona Nantuinna Covona
+			Arausa Auleda Bodocena Navia Nicer Turciradin Valuinna Galisama Sulona Nanterta Osmubodva Cataseibra Cunila Cunona 
+			Epubodva Vevicca Nemetantona Bouderta Brigentina Androna Agrosuelta Matrila Osmerta Andricca Caterta Rigentina Belisama 
+			Sulantona Morgisama Agraseibra Osmila Covicca Morgosuelt Sulila Veventina Matrantona Ardona Rigantia Valubodva Matrantia 
+			Androsuelta Agrentina Valila Covisama Belentina Senosuelta Catosuelta Galubodva Brigantona Morgasta Sulosuelta Volcerta 
+			Covantia Senisama Matrubodva Sirasta Rigubodva Morgerta Sirantia Epila Senantona Nantuinna Covona
 		}
 
 		from_dynasty_prefix = "ab " # from
@@ -4963,6 +4975,7 @@ continental_celtic = {
 		color = { 0.3 0.8 0.8 }
 
 		male_names = {
+			Antorbanen Bodo Sekaiza Cado Deobrigo Dovidero Durato Elguismio Segisamo Turenno  
 			Aaron_Aaron Abbán Abner_Abner Abél_Abel Adomnán Affiath Ailbe Ailbrend Ailbrenn Ailchú Aildobur Ailgel Ailgus Ailill Ainbchellach Ainmere Airechtach
 			Airfhindán Airfhinnán Airleid Airmedach Amalgaid Anfudán Anlón Anmchaid Ardgal Ardgar Art_Arthur Artbran Artgal Artgus Artucán Artúr_Arthur
 			Assiucc Augustín_Augustine Aurthuile Barrfhind Beccán Berrach Blathmacc Bran Brangen Bressal Briccéne Briccíne Broccán Bruatur Bruide Brénaind
@@ -4989,7 +5002,7 @@ continental_celtic = {
 			Échtgus Éicnech Éochad Éogan_Eugene Éremón Érennach Óengus Óenucán Ólchobar Úamnachán
 		}
 		female_names = {
-			Ablach Affraic Aileann Anlaith Aróc Aíbinn Barrdub Ben-Laigen Brigit Bé-Fáil Bébinn Caillech-Fhinnéin Cainnech Caisséne Catan Caíntigern Caírech
+			Amia Ablach Affraic Aileann Anlaith Aróc Aíbinn Barrdub Ben-Laigen Brigit Bé-Fáil Bébinn Caillech-Fhinnéin Cainnech Caisséne Catan Caíntigern Caírech
 			Cellach Ciar Cnes Coblaith Conchenn Condál Crínóch Cumman Der-bForgaill_Devorguilla Derbáil Dianaim Doriend Dub-Essa Dub-Lemna Dubchoblaig Dubgilla Dúinsech
 			Dúnlaith Echrad Eithne Ellbríg Euginia_Eugenia Faílenn Fedelm Finneacht Finnguala Flann Forbflaith Fíne Garb Gelgéis Gerróc Gnathnad Gormlaith
 			Lathir Lerben Lerthan Lígach Martha Muirenn Muirgel Máel-Mide Máel-Muire Mór Mór-Muman Nárbflaith Sadb Samthann Sebdann Selblaith Sinech Suaibsech

--- a/WTWSMS/common/landed_titles/WtWSMS_kingdoms.txt
+++ b/WTWSMS/common/landed_titles/WtWSMS_kingdoms.txt
@@ -1478,7 +1478,7 @@ k_thuringia = {
 k_saxony = {
 	color={ 113 101 91 }
 	
-	capital = 310 #	Anhalt
+	capital = 259 #	Celle
 	
 	culture = old_saxon
 	
@@ -2550,7 +2550,7 @@ e_saxony = {
 	color={ 176 177 144 }
 	color2={ 220 220 20 }
 	
-	capital = 310 #	Anhalt
+	capital = 259 #	Celle
 
 	short_name = yes
 	


### PR DESCRIPTION
- Moved the Saxon capital from Anhalt to Celle
- Modified the name lists for the Astures and and Cantabrian cultures