### PR TITLE
Fixed Broken Cretan Feast Decision

### DIFF
--- a/WTWSMS/decisions/VIET_culture_decisions.txt
+++ b/WTWSMS/decisions/VIET_culture_decisions.txt
@@ -666,11 +666,6 @@ decisions = {
 						province_id = 480
 					}
 				}
-				AND = {
-					any_realm_lord = { has_landed_title = c_kaneia }
-					any_realm_lord = { has_landed_title = c_chandax }
-				}
-				completely_controls = d_krete
 			}
 			NOT = { has_character_modifier = VIET_cretan_feast_timer }
 			NOT = { has_character_flag = do_not_disturb }


### PR DESCRIPTION
- The decision no longer appears for lieges of Cretes with no actual
connection to the island